### PR TITLE
upgraded to support sonar version from 8.9+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,9 +104,10 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <htl.version>1.1.2-1.4.0</htl.version>
-    <sonar.version>7.9.2</sonar.version>
+    <sonar.version>8.9.6.50800</sonar.version>
     <sonar.html.version>3.0.1.1444</sonar.html.version>
-    <sonar.java.plugin>6.2.0.21135</sonar.java.plugin>
+    <sonar.java.plugin>7.6.0.28201</sonar.java.plugin>
+    <sonar-java-checks-testkit-version>7.6.0.28201</sonar-java-checks-testkit-version>
     <coveralls.repo.token>4rVf3NGV0jyQ3EGrc8L86oEDoHWm6MgDD</coveralls.repo.token>
     <tagName>v${project.version}</tagName>
   </properties>
@@ -133,12 +134,21 @@
       <artifactId>org.apache.sling.scripting.sightly.compiler</artifactId>
       <version>${htl.version}</version>
     </dependency>
+
+    <!-- sonarsource version -->
     <dependency>
       <groupId>org.sonarsource.sonarqube</groupId>
       <artifactId>sonar-plugin-api</artifactId>
       <version>${sonar.version}</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.sonarsource.sonarqube</groupId>
+      <artifactId>sonar-plugin-api-impl</artifactId>
+      <version>${sonar.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
     <dependency>
       <groupId>org.sonarsource.java</groupId>
       <artifactId>sonar-java-plugin</artifactId>
@@ -212,7 +222,7 @@
     <dependency>
       <groupId>org.sonarsource.java</groupId>
       <artifactId>java-checks-testkit</artifactId>
-      <version>${sonar.java.plugin}</version>
+      <version>${sonar-java-checks-testkit-version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -297,6 +307,12 @@
       <groupId>org.osgi</groupId>
       <artifactId>org.osgi.service.component.annotations</artifactId>
       <version>1.3.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>26.0-jre</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/com/cognifide/aemrules/java/checks/AdministrativeAccessUsageCheck.java
+++ b/src/main/java/com/cognifide/aemrules/java/checks/AdministrativeAccessUsageCheck.java
@@ -82,9 +82,7 @@ public class AdministrativeAccessUsageCheck extends IssuableSubscriptionVisitor 
 
     @Override
     public void visitNode(Tree tree) {
-        if (this.hasSemantic()) {
-            matchers.forEach(invocationMatcher -> this.checkInvocation(tree, invocationMatcher));
-        }
+        matchers.forEach(invocationMatcher -> this.checkInvocation(tree, invocationMatcher));
     }
 
     private void checkInvocation(Tree tree, MethodMatcher invocationMatcher) {

--- a/src/test/java/com/cognifide/aemrules/extensions/RulesLoaderTest.java
+++ b/src/test/java/com/cognifide/aemrules/extensions/RulesLoaderTest.java
@@ -34,7 +34,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.api.server.rule.RulesDefinition.NewRepository;
-import org.sonar.api.server.rule.RulesDefinition.RepositoryImpl;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
 import org.sonar.check.RuleProperty;
@@ -76,7 +75,7 @@ public class RulesLoaderTest {
     public void shouldLoadRuleWithAllSettings() {
         givenRulesLoaded(Arrays.asList(RuleWithAllSettings.class));
 
-        RepositoryImpl repository = (RepositoryImpl) context.repository(JavaCheckClasses.REPOSITORY_KEY);
+        RulesDefinition.Repository repository = context.repository(JavaCheckClasses.REPOSITORY_KEY);
         RulesDefinition.Rule rule = repository.rule(RULE_KEY);
 
         Assert.assertThat(rule.markdownDescription(), is(RULE_MARKDOWN_TEST_DESCRIPTION));
@@ -90,7 +89,7 @@ public class RulesLoaderTest {
     public void shouldNotSetTechnicalDebtWhenAnnotationNotPresent() {
         givenRulesLoaded(Arrays.asList(RuleWithoutMetadataAnnotation.class));
 
-        RepositoryImpl repository = (RepositoryImpl) context.repository(JavaCheckClasses.REPOSITORY_KEY);
+        RulesDefinition.Repository repository = context.repository(JavaCheckClasses.REPOSITORY_KEY);
         RulesDefinition.Rule rule = repository.rule(RULE_KEY);
 
         Assert.assertThat(rule.markdownDescription(), is(RULE_MARKDOWN_TEST_DESCRIPTION));
@@ -104,7 +103,7 @@ public class RulesLoaderTest {
     public void shouldNotSetTechnicalDebtWhenTechnicalDebtNotSetInMetadata() {
         givenRulesLoaded(Arrays.asList(RuleWithEmptyTechnicalDebt.class));
 
-        RepositoryImpl repository = (RepositoryImpl) context.repository(JavaCheckClasses.REPOSITORY_KEY);
+        RulesDefinition.Repository repository = context.repository(JavaCheckClasses.REPOSITORY_KEY);
         RulesDefinition.Rule rule = repository.rule(RULE_KEY);
 
         Assert.assertThat(rule.markdownDescription(), is(RULE_MARKDOWN_TEST_DESCRIPTION));
@@ -118,7 +117,7 @@ public class RulesLoaderTest {
     public void shouldNotLoadRuleWhenRuleAnnotationIsNotPresent() {
         givenRulesLoaded(Arrays.asList(RuleWithoutRuleAnnotation.class));
 
-        RepositoryImpl repository = (RepositoryImpl) context.repository(JavaCheckClasses.REPOSITORY_KEY);
+        RulesDefinition.Repository repository = context.repository(JavaCheckClasses.REPOSITORY_KEY);
         RulesDefinition.Rule rule = repository.rule(RULE_KEY);
 
         Assert.assertThat(rule, is(nullValue()));
@@ -129,7 +128,7 @@ public class RulesLoaderTest {
     public void shouldSetDefaultValuesWhenRuleAttributeWithNameOnly() {
         givenRulesLoaded(Arrays.asList(RuleWithOnlyNameAttribute.class));
 
-        RepositoryImpl repository = (RepositoryImpl) context.repository(JavaCheckClasses.REPOSITORY_KEY);
+        RulesDefinition.Repository repository = context.repository(JavaCheckClasses.REPOSITORY_KEY);
         RulesDefinition.Rule rule = repository.rule("com.cognifide.aemrules.extensions.RulesLoaderTest.RuleWithOnlyNameAttribute");
 
         Assert.assertThat(rule.markdownDescription(), is("No description yet."));
@@ -148,7 +147,7 @@ public class RulesLoaderTest {
     public void shouldLoadRuleWithProperty() {
         givenRulesLoaded(Arrays.asList(RuleWithRuleProperty.class));
 
-        RepositoryImpl repository = (RepositoryImpl) context.repository(JavaCheckClasses.REPOSITORY_KEY);
+        RulesDefinition.Repository repository = context.repository(JavaCheckClasses.REPOSITORY_KEY);
         RulesDefinition.Rule rule = repository.rule(RULE_KEY);
         RulesDefinition.Param param = rule.param(RULE_PROPERTY_KEY);
 
@@ -161,7 +160,7 @@ public class RulesLoaderTest {
     public void shouldLoadRuleWithPropertyWithoutAttributes() {
         givenRulesLoaded(Arrays.asList(RuleWithRulePropertyWithoutAttributes.class));
 
-        RepositoryImpl repository = (RepositoryImpl) context.repository(JavaCheckClasses.REPOSITORY_KEY);
+        RulesDefinition.Repository repository = context.repository(JavaCheckClasses.REPOSITORY_KEY);
         RulesDefinition.Rule rule = repository.rule(RULE_KEY);
         RulesDefinition.Param param = rule.param("testProperty");
 

--- a/src/test/java/com/cognifide/aemrules/htl/visitors/HtlScannerTest.java
+++ b/src/test/java/com/cognifide/aemrules/htl/visitors/HtlScannerTest.java
@@ -34,7 +34,7 @@ import org.apache.sling.scripting.sightly.compiler.expression.Expression;
 import org.junit.Before;
 import org.junit.Test;
 import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
-import org.sonar.api.internal.google.common.io.Files;
+import com.google.common.io.Files;
 import org.sonar.plugins.html.api.HtmlConstants;
 import org.sonar.plugins.html.node.CommentNode;
 import org.sonar.plugins.html.node.Node;

--- a/src/test/java/com/cognifide/aemrules/java/checks/AbstractBaseTest.java
+++ b/src/test/java/com/cognifide/aemrules/java/checks/AbstractBaseTest.java
@@ -24,7 +24,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
-import org.sonar.java.checks.verifier.JavaCheckVerifier;
+import org.sonar.java.checks.verifier.CheckVerifier;
 import org.sonar.plugins.java.api.JavaFileScanner;
 
 public abstract class AbstractBaseTest {
@@ -66,13 +66,23 @@ public abstract class AbstractBaseTest {
 
     protected void verify(boolean withJarClassPath) {
         if (withJarClassPath) {
-            JavaCheckVerifier.verify(filename, check, CLASSPATH_JAR);
+            CheckVerifier.newVerifier()
+                    .onFile(filename)
+                    .withCheck(check)
+                    .withClassPath(CLASSPATH_JAR)
+                    .verifyIssues();
         } else {
-            JavaCheckVerifier.verify(filename, check);
+            CheckVerifier.newVerifier()
+                    .onFile(filename)
+                    .withCheck(check)
+                    .verifyIssues();
         }
     }
 
     protected void verifyNoIssues() {
-        JavaCheckVerifier.verifyNoIssue(filename, check);
+        CheckVerifier.newVerifier()
+                .onFile(filename)
+                .withCheck(check)
+                .verifyNoIssues();
     }
 }

--- a/src/test/java/com/cognifide/aemrules/matcher/MethodMatcherTest.java
+++ b/src/test/java/com/cognifide/aemrules/matcher/MethodMatcherTest.java
@@ -22,6 +22,7 @@ package com.cognifide.aemrules.matcher;
 import org.junit.Assert;
 import org.junit.Test;
 import org.sonar.java.model.JParser;
+import org.sonar.java.model.JParserConfig;
 import org.sonar.plugins.java.api.tree.ClassTree;
 import org.sonar.plugins.java.api.tree.CompilationUnitTree;
 import org.sonar.plugins.java.api.tree.ExpressionStatementTree;
@@ -161,7 +162,7 @@ public class MethodMatcherTest {
 
     private CompilationUnitTree parse(String source) {
         List<File> classpath = Arrays.asList(new File(TEST_CLASSES_FILEPATH), new File(CLASSES_FILEPATH));
-        return JParser.parse(JAVA_VERSION, UNIT_NAME, source, classpath);
+        return JParser.parse(JParserConfig.Mode.FILE_BY_FILE.create(JAVA_VERSION, classpath).astParser(), JAVA_VERSION, UNIT_NAME, source);
     }
 
 }


### PR DESCRIPTION
- Upgraded to support from sonar version to `8.9+`
- Added `sonar-plugin-api-impl` to test cases
- `sonar.java.plugin` has been upgraded to `7.6.0.28201` because of sonar version `8.9+`